### PR TITLE
fixup: modules: separate library into modules

### DIFF
--- a/src/advanced_string_table.rs
+++ b/src/advanced_string_table.rs
@@ -1,0 +1,27 @@
+use alloc::vec::Vec;
+use hashbrown::HashMap;
+
+pub struct StringTable {
+    pub buffer: Vec<u8>,
+    index: HashMap<String, u32>,
+}
+
+impl StringTable {
+    pub fn new() -> StringTable {
+        StringTable {
+            buffer: Vec::new(),
+            index: HashMap::new(),
+        }
+    }
+
+    pub fn add_string(&mut self, val: &str) -> u32 {
+        if let Some(offset) = self.index.get(val) {
+            return *offset;
+        }
+        let offset = self.buffer.len() as u32;
+        self.buffer.extend(val.bytes());
+        self.buffer.push(0);
+        self.index.insert(val.to_string(), offset);
+        offset
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,93 @@
+/// Convenience alias for the [`Result`](core::result::Result) type.
+pub type Result<T> = core::result::Result<T, DeviceTreeError>;
+
+pub type SliceReadResult<T> = core::result::Result<T, SliceReadError>;
+
+pub type VecWriteResult = core::result::Result<(), VecWriteError>;
+
+/// An error describe parsing problems when creating device trees.
+#[derive(Debug)]
+pub enum DeviceTreeError {
+    /// The magic number `MAGIC_NUMBER` was not found at the start of the
+    /// structure.
+    InvalidMagicNumber,
+
+    /// An offset or size found inside the device tree is outside of what was
+    /// supplied to `load()`.
+    SizeMismatch,
+
+    /// Failed to read data from slice.
+    SliceReadError(SliceReadError),
+
+    /// The data format was not as expected at the given position
+    ParseError(usize),
+
+    /// While trying to convert a string that was supposed to be ASCII, invalid
+    /// utf8 sequences were encounted
+    Utf8Error,
+
+    /// The device tree version is not supported by this library.
+    VersionNotSupported,
+
+    /// The device tree structure could not be serialized to DTB
+    VecWriteError(VecWriteError),
+
+    /// Property could not be parsed
+    PropError(PropError),
+}
+
+impl From<SliceReadError> for DeviceTreeError {
+    fn from(e: SliceReadError) -> DeviceTreeError {
+        DeviceTreeError::SliceReadError(e)
+    }
+}
+
+impl From<VecWriteError> for DeviceTreeError {
+    fn from(e: VecWriteError) -> DeviceTreeError {
+        DeviceTreeError::VecWriteError(e)
+    }
+}
+
+impl From<PropError> for DeviceTreeError {
+    fn from(e: PropError) -> Self {
+        Self::PropError(e)
+    }
+}
+
+impl From<core::str::Utf8Error> for DeviceTreeError {
+    fn from(_: core::str::Utf8Error) -> DeviceTreeError {
+        DeviceTreeError::Utf8Error
+    }
+}
+
+/// Represents property errors.
+#[derive(Debug)]
+pub enum PropError {
+    NotFound,
+    Utf8Error,
+    Missing0,
+    SliceReadError(SliceReadError),
+}
+
+impl From<core::str::Utf8Error> for PropError {
+    fn from(_: core::str::Utf8Error) -> PropError {
+        PropError::Utf8Error
+    }
+}
+
+impl From<SliceReadError> for PropError {
+    fn from(e: SliceReadError) -> PropError {
+        PropError::SliceReadError(e)
+    }
+}
+
+#[derive(Debug)]
+pub enum SliceReadError {
+    UnexpectedEndOfInput,
+}
+
+#[derive(Debug)]
+pub enum VecWriteError {
+    NonContiguousWrite,
+    UnalignedWrite,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,13 @@
 /// Convenience alias for the [`Result`](core::result::Result) type.
-pub type Result<T> = core::result::Result<T, DeviceTreeError>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 pub type SliceReadResult<T> = core::result::Result<T, SliceReadError>;
 
 pub type VecWriteResult = core::result::Result<(), VecWriteError>;
 
 /// An error describe parsing problems when creating device trees.
-#[derive(Debug)]
-pub enum DeviceTreeError {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Error {
     /// The magic number `MAGIC_NUMBER` was not found at the start of the
     /// structure.
     InvalidMagicNumber,
@@ -36,32 +36,32 @@ pub enum DeviceTreeError {
     PropError(PropError),
 }
 
-impl From<SliceReadError> for DeviceTreeError {
-    fn from(e: SliceReadError) -> DeviceTreeError {
-        DeviceTreeError::SliceReadError(e)
+impl From<SliceReadError> for Error {
+    fn from(e: SliceReadError) -> Error {
+        Error::SliceReadError(e)
     }
 }
 
-impl From<VecWriteError> for DeviceTreeError {
-    fn from(e: VecWriteError) -> DeviceTreeError {
-        DeviceTreeError::VecWriteError(e)
+impl From<VecWriteError> for Error {
+    fn from(e: VecWriteError) -> Error {
+        Error::VecWriteError(e)
     }
 }
 
-impl From<PropError> for DeviceTreeError {
+impl From<PropError> for Error {
     fn from(e: PropError) -> Self {
         Self::PropError(e)
     }
 }
 
-impl From<core::str::Utf8Error> for DeviceTreeError {
-    fn from(_: core::str::Utf8Error) -> DeviceTreeError {
-        DeviceTreeError::Utf8Error
+impl From<core::str::Utf8Error> for Error {
+    fn from(_: core::str::Utf8Error) -> Error {
+        Error::Utf8Error
     }
 }
 
 /// Represents property errors.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PropError {
     NotFound,
     Utf8Error,
@@ -81,12 +81,12 @@ impl From<SliceReadError> for PropError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SliceReadError {
     UnexpectedEndOfInput,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum VecWriteError {
     NonContiguousWrite,
     UnalignedWrite,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,18 +119,18 @@ impl DeviceTree {
         // 36  size_dt_struct: u32,
 
         if buffer.read_be_u32(0)? != MAGIC_NUMBER {
-            return Err(DeviceTreeError::InvalidMagicNumber);
+            return Err(Error::InvalidMagicNumber);
         }
 
         // check total size
         if buffer.read_be_u32(4)? as usize != buffer.len() {
-            return Err(DeviceTreeError::SizeMismatch);
+            return Err(Error::SizeMismatch);
         }
 
         // check version
         let version = buffer.read_be_u32(20)?;
         if version != SUPPORTED_VERSION {
-            return Err(DeviceTreeError::VersionNotSupported);
+            return Err(Error::VersionNotSupported);
         }
 
         let off_dt_struct = buffer.read_be_u32(8)? as usize;
@@ -254,7 +254,7 @@ impl Node {
     ) -> Result<(usize, Node)> {
         // check for DT_BEGIN_NODE
         if buffer.read_be_u32(start)? != OF_DT_BEGIN_NODE {
-            return Err(DeviceTreeError::ParseError(start));
+            return Err(Error::ParseError(start));
         }
 
         let raw_name = buffer.read_bstring0(start + 4)?;
@@ -292,7 +292,7 @@ impl Node {
         }
 
         if buffer.read_be_u32(pos)? != OF_DT_END_NODE {
-            return Err(DeviceTreeError::ParseError(pos));
+            return Err(Error::ParseError(pos));
         }
 
         pos += 4;

--- a/src/string_table.rs
+++ b/src/string_table.rs
@@ -1,0 +1,24 @@
+use alloc::vec::Vec;
+
+pub struct StringTable {
+    pub buffer: Vec<u8>,
+}
+
+impl Default for StringTable {
+    fn default() -> Self {
+        StringTable::new()
+    }
+}
+
+impl StringTable {
+    pub fn new() -> StringTable {
+        StringTable { buffer: Vec::new() }
+    }
+
+    pub fn add_string(&mut self, val: &str) -> u32 {
+        let offset = self.buffer.len();
+        self.buffer.extend(val.bytes());
+        self.buffer.push(0);
+        offset as u32
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,17 +1,12 @@
 use alloc::vec::Vec;
 pub use core::{convert, fmt, option, result, str};
 
+use crate::{SliceReadError, SliceReadResult, VecWriteError, VecWriteResult};
+
 #[inline]
 pub fn align(val: usize, to: usize) -> usize {
     val + (to - (val % to)) % to
 }
-
-#[derive(Debug)]
-pub enum SliceReadError {
-    UnexpectedEndOfInput,
-}
-
-pub type SliceReadResult<T> = Result<T, SliceReadError>;
 
 pub trait SliceRead {
     fn read_be_u32(&self, pos: usize) -> SliceReadResult<u32>;
@@ -70,14 +65,6 @@ impl<'a> SliceRead for &'a [u8] {
         Ok(&self[start..end])
     }
 }
-
-#[derive(Debug)]
-pub enum VecWriteError {
-    NonContiguousWrite,
-    UnalignedWrite,
-}
-
-pub type VecWriteResult = Result<(), VecWriteError>;
 
 pub trait VecWrite {
     fn write_be_u32(&mut self, pos: usize, val: u32) -> VecWriteResult;


### PR DESCRIPTION
Separates library types into modules for better readability and maintainability.

Minor fixes for library error types.